### PR TITLE
Fixes duplicate users in module list.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -120,7 +120,7 @@ class modHelloWorldHelper
 //OLD 	$fetch_sql = $fetch_sql . $select_sql;
 
 	// echo $fetch_sql . "<br>";
-
+	$fetch_sql .= ' GROUP BY u.id';
 	//Add ordering if list is configured for that
 	if ($userlistorder <>'') { $fetch_sql .= " ORDER BY ".$userlistorder; }
 


### PR DESCRIPTION
When a user is in several groups in the joomla user system, the query that fetches all users in a cb list will produce more than one row with the same user id.
This is fixed by grouping the results by the joomla user id, making each row user-unique.
I have not checked for side effects, but from what I can gather each row is supposed to be user-unique.