### PR TITLE
Prepare 2.3 release

### DIFF
--- a/mod_hqcblistmodule.xml
+++ b/mod_hqcblistmodule.xml
@@ -3,8 +3,8 @@
     <name>HQ CB List for Community Builder</name>
     <author>Magnus Hasselquist</author>
     <authorUrl>https://github.com/magnushasselquist</authorUrl>
-    <version>2.2</version>
-    <creationDate>2021-03-15</creationDate>
+    <version>2.3</version>
+    <creationDate>2021-05-07</creationDate>
     <license>GNU General Public License version 2 or later</license>
     <description>Displaying Users from a selected CB List in a Module. This version is for CB 2</description>
     <files>

--- a/updates.xml
+++ b/updates.xml
@@ -5,7 +5,7 @@
         <description>HQ List for Community Builder</description>
         <element>mod_hqcblistmodule</element>
         <type>module</type>
-        <version>2.2</version>
+        <version>2.3</version>
         <infourl title="Release notes">http://magnushasselquist.github.io/hqcblistmodule/</infourl>
         <downloads>
             <downloadurl type="full" format="zip">https://github.com/magnushasselquist/hqcblistmodule/zipball/master</downloadurl>


### PR DESCRIPTION
Hi Magnus,

I did some testing for a new release only (new) thing what i found was with 'usergroup selection' which has been fixed.

In this pull i update the version number to 2.3. Only thing to do is create a new github release so that the link in updates.xml retrieves the 2.3 version instead of the 2.2.

**Changelog for 2.3**
Add: [sort order options](https://github.com/magnushasselquist/hqcblistmodule/pull/16)
improve: [Keep text inside div](https://github.com/magnushasselquist/hqcblistmodule/pull/13)
Fix: [Only show published lists](https://github.com/magnushasselquist/hqcblistmodule/pull/14)
Fix: [contains filter did not work](https://github.com/magnushasselquist/hqcblistmodule/pull/15)
Fix: [usergroup selection](https://github.com/magnushasselquist/hqcblistmodule/pull/17)
Fix: [Error if list has no filters](https://github.com/magnushasselquist/hqcblistmodule/pull/12/commits/e03e8893b654a5df3956cff265c4e2bf5085afb5)
